### PR TITLE
Added video thumbnail loader

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="Reels_Player.app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
@@ -13,7 +14,6 @@
             <option value="$PROJECT_DIR$/reelsplayer" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,30 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
@@ -8,6 +32,9 @@
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
@@ -32,6 +59,9 @@
     <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/stacktrace-idea.xml
+++ b/.idea/stacktrace-idea.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StacktraceSettings">
+    <option name="folders">
+      <set>
+        <option value="$PROJECT_DIR$/app/build/generated/res/resValues/debug" />
+        <option value="$PROJECT_DIR$/app/src/androidTest/java" />
+        <option value="$PROJECT_DIR$/app/src/main/java" />
+        <option value="$PROJECT_DIR$/app/src/main/res" />
+        <option value="$PROJECT_DIR$/app/src/test/java" />
+        <option value="$PROJECT_DIR$/reelsplayer/build/generated/res/resValues/debug" />
+        <option value="$PROJECT_DIR$/reelsplayer/src/main/java" />
+      </set>
+    </option>
+    <option name="packages">
+      <set>
+        <option value="com.shahid.iqbal" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/reelsplayer/build.gradle.kts
+++ b/reelsplayer/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation("androidx.media3:media3-ui:1.4.1")
     implementation("androidx.media3:media3-exoplayer-hls:1.4.1")
 
+    implementation(libs.coil.compose)
 
 }
 

--- a/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/DefaultVideoLoader.kt
+++ b/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/DefaultVideoLoader.kt
@@ -1,12 +1,18 @@
 package com.shahid.iqbal.reelsplayer.components
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 
 /*
  * Created by Shahid Iqbal on 7/20/2024.
@@ -19,6 +25,7 @@ import androidx.compose.ui.unit.dp
  * @param modifier A [Modifier] to apply to this layout.
  * @param progressColor The color of the progress indicator.
  * @param strokeWidth The width of the stroke for the progress indicator.
+ * @param thumbnail Bitmap of video thumbnail
  */
 
 @Composable
@@ -26,11 +33,23 @@ fun DefaultVideoLoader(
     modifier: Modifier = Modifier,
     progressColor: Color = Color.White,
     strokeWidth: Dp = 5.dp,
+    thumbnail: Bitmap? = null
 ) {
-    CircularProgressIndicator(
-        modifier = modifier,
-        color = progressColor,
-        strokeWidth = strokeWidth,
-        strokeCap = StrokeCap.Round
-    )
+    Box(modifier = modifier) {
+        AsyncImage(
+            modifier = modifier,
+            model = thumbnail,
+            contentDescription = "Video thumbnail",
+            contentScale = ContentScale.Crop
+        )
+        CircularProgressIndicator(
+            modifier = Modifier
+                .align(alignment = Alignment.Center)
+                .size(50.dp),
+            color = progressColor,
+            strokeWidth = strokeWidth,
+            strokeCap = StrokeCap.Round
+        )
+    }
+
 }

--- a/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/PageContent.kt
+++ b/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/PageContent.kt
@@ -1,5 +1,6 @@
 package com.shahid.iqbal.reelsplayer.components
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,12 +19,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
+import com.shahid.iqbal.reelsplayer.actions.VideoSource
 import com.shahid.iqbal.reelsplayer.configs.ReelsConfig
+import com.shahid.iqbal.reelsplayer.configs.ReelsConfigUtils.getVideoThumbnail
 import com.shahid.iqbal.reelsplayer.configs.ReelsConfigUtils.setPlayerAttributes
 
 /*
@@ -38,20 +43,24 @@ fun PageContent(
     pagerState: PagerState,
     reelConfig: ReelsConfig,
     isPlayerLoading: Boolean,
+    videoSource: VideoSource,
 ) {
-
     var showControlsMenu by remember {
         mutableStateOf(false)
     }
 
+    val context = LocalContext.current
+    var thumbnail by remember(videoSource) { mutableStateOf<Bitmap?>(null) }
 
+    LaunchedEffect(Unit){
+        thumbnail= getVideoThumbnail(context,videoSource)
+    }
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Color.Black)
     ) {
-
         if (page == pagerState.currentPage) {
 
             AndroidView({ ctx ->
@@ -66,13 +75,11 @@ fun PageContent(
                     setOnClickListener {
                         showControlsMenu = !showControlsMenu
 
-                        if (showControlsMenu)
-                            showController()
+                        if (showControlsMenu) showController()
                         else hideController()
                     }
                 }
-            }, modifier = Modifier
-                .fillMaxSize(), update = {
+            }, modifier = Modifier.fillMaxSize(), update = { playerView ->
                 exoPlayer.playWhenReady = true
             }, onRelease = {
                 it.player = null
@@ -81,10 +88,8 @@ fun PageContent(
             /*Show Loader If Player is Buffering*/
             if (isPlayerLoading) {
                 reelConfig.playerLoader?.invoke() ?: DefaultVideoLoader(
-                    modifier = Modifier
-                        .size(50.dp)
-                        .align(Alignment.Center)
-
+                    modifier = Modifier.fillMaxSize().align(Alignment.Center),
+                    thumbnail = thumbnail
                 )
             }
         }

--- a/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/ReelsPlayer.kt
+++ b/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/components/ReelsPlayer.kt
@@ -167,7 +167,8 @@ fun ReelsPlayer(
             page = page,
             pagerState = pageState,
             reelConfig = reelConfig,
-            isPlayerLoading = playerUiState.isLoading
+            isPlayerLoading = playerUiState.isLoading,
+            videoSource = videoList[page]
         )
     }
 }

--- a/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/configs/ReelsConfigUtils.kt
+++ b/reelsplayer/src/main/java/com/shahid/iqbal/reelsplayer/configs/ReelsConfigUtils.kt
@@ -1,6 +1,9 @@
 package com.shahid.iqbal.reelsplayer.configs
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.os.Environment
 import android.os.StatFs
 import android.view.View
@@ -22,9 +25,11 @@ import com.shahid.iqbal.reelsplayer.actions.PlayerResizeMode
 import com.shahid.iqbal.reelsplayer.actions.RepeatMode
 import com.shahid.iqbal.reelsplayer.actions.ThumbnailDisplayMode
 import com.shahid.iqbal.reelsplayer.actions.VideoScalingMode
+import com.shahid.iqbal.reelsplayer.actions.VideoSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /*
@@ -89,5 +94,48 @@ object ReelsConfigUtils {
 
         hideControllersViews()
     }
+
+
+    /*
+    * This function will get the video thumbnail and return as a bitmap
+    * if its successful in retrieving it.
+    */
+
+    suspend fun getVideoThumbnail(context: Context, source: VideoSource): Bitmap? =
+        withContext(Dispatchers.IO) {
+            try {
+                val retriever = MediaMetadataRetriever()
+
+                when (source) {
+                    is VideoSource.UrlResource -> {
+                        retriever.setDataSource(source.videoUrl, HashMap()) // Network
+                    }
+
+                    is VideoSource.RawResource -> {
+                        val uri =
+                            Uri.parse("android.resource://${context.packageName}/${source.resourceId}")
+                        retriever.setDataSource(context, uri)
+                    }
+
+                    is VideoSource.AssetResource -> {
+                        val afd = context.assets.openFd(source.assetPath)
+                        retriever.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                        afd.close()
+                    }
+
+                    is VideoSource.HlsResource -> {
+                        // Might fail — HLS (m3u8) is not always supported
+                        retriever.setDataSource(source.streamingUrl, HashMap())
+                    }
+                }
+
+                val frame = retriever.getFrameAtTime(0, MediaMetadataRetriever.OPTION_CLOSEST)
+                retriever.release()
+                frame
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+        }
 
 }


### PR DESCRIPTION
Added Video thumbnail at buffering, in case video is taking too much time because of slow internet (specifically from URL) before this only a blank screen and loaders shows all time of buffering, but now black screen will be shown until thumbnail is not loaded, but when thumbnail gets loaded it will be set on whole screen and remaining buffering will happen on that thumbnail, this will improve user experience, I tried to make it like Reddit shorts flow.


Additionally, I have removed the following lines from the ReelsPlayer.kt file because I found them redundant, as we are already receiving the videoList and index from the parameters.

```
 val listOfVideos = remember { videoList }
 val index by remember { mutableIntStateOf(indexOfVideo) }
````
